### PR TITLE
Add Boardgame Search, Improve Error Responses

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,7 @@
     "date-fns": "2.8.1",
     "dotenv": "8.2.0",
     "express": "4.17.1",
+    "fuse.js": "3.4.6",
     "googleapis": "46.0.0",
     "graphql": "14.5.8",
     "graphql-tag": "2.10.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,6 +24,7 @@
     "graphql-type-json": "0.3.1",
     "helmet": "3.21.2",
     "jsonwebtoken": "8.5.1",
+    "node-cache": "5.1.0",
     "pg": "7.17.0",
     "reflect-metadata": "0.1.13",
     "superagent": "5.1.3",

--- a/packages/server/seeders/main.ts
+++ b/packages/server/seeders/main.ts
@@ -55,6 +55,10 @@ const insertBoardgames = async () =>
       ...GAMES.wingspan.boardgame,
       createdAt: faker.date.between(eras[0], eras[1]),
     }).save(),
+    new Boardgame({
+      ...GAMES.wonders.boardgame,
+      createdAt: faker.date.between(eras[0], eras[1]),
+    }).save(),
   ])
 
 const insertUsers = async () =>

--- a/packages/server/seeders/main.ts
+++ b/packages/server/seeders/main.ts
@@ -3,11 +3,10 @@ import faker from 'faker'
 import { addDays } from 'date-fns'
 
 import { connectToDatabase } from '@/db'
-import { Boardgame, GAME_TYPE } from '@/modules/boardgame/boardgame.model'
+import { Boardgame } from '@/modules/boardgame/boardgame.model'
 import { Friendship } from '@/modules/friendship/friendship.model'
 import { Match } from '@/modules/match/match.model'
 import { User } from '@/modules/user/user.model'
-import { JsonSchemaObject } from '@/types/json-schema'
 import { generateUser } from '@/utils/tests'
 import { GAMES } from '@/utils/test-data'
 import { randomItem } from '@/utils'
@@ -33,26 +32,6 @@ const eras = [
   addDays(FIRST_DATE, 21),
 ] as const
 
-const createBoardgameSchema = <PR extends Omit<JsonSchemaObject, 'type'>>(
-  playerResults?: PR,
-) => ({
-  $schema: 'http://json-schema.org/draft-07/schema#' as const,
-  type: 'object' as const,
-  required: ['player', 'winner', 'final', ...(playerResults?.required ?? [])],
-  properties: {
-    player: {
-      type: 'string' as const,
-    },
-    winner: {
-      type: 'boolean' as const,
-    },
-    final: {
-      type: 'number' as const,
-    },
-    ...playerResults?.properties,
-  },
-})
-
 // Board games with (mock) in the name don't have a unique result schema
 const insertBoardgames = async () =>
   Promise.all([
@@ -65,78 +44,15 @@ const insertBoardgames = async () =>
       createdAt: faker.date.between(eras[0], eras[1]),
     }).save(),
     new Boardgame({
-      type: GAME_TYPE.COMPETITIVE,
-      name: 'Terraforming Mars (mock)',
-      shortName: 'terraforming-mars',
-      aliases: [
-        'A Mars terraformálása',
-        'Mars: Teraformace',
-        'Teraformarea Planetei Marte',
-        'Terraformacja Marsa',
-        'Покорение Марса',
-        'Тераформирай Марс',
-        'Тераформування Марса',
-        'พลิกพิภพดาวอังคาร',
-        'テラフォーミング・マーズ',
-        '殖民火星',
-        '테라포밍 마스',
-      ],
-      thumbnail:
-        'https://cf.geekdo-images.com/itemrep/img/bhemoxL7PG1a_79L0D9syPTADSY=/fit-in/246x300/pic3536616.jpg',
-      url: 'https://boardgamegeek.com/boardgame/167791/terraforming-mars',
-      rulebook: null,
-      minPlayers: 1,
-      maxPlayers: 5,
-      resultsSchema: createBoardgameSchema(),
+      ...GAMES.mars.boardgame,
       createdAt: faker.date.between(eras[0], eras[1]),
     }).save(),
     new Boardgame({
-      type: GAME_TYPE.COMPETITIVE,
-      name: 'Wingspan (mock)',
-      shortName: 'wingspan',
-      aliases: [
-        'Fesztáv',
-        'Flügelschlag',
-        'Na křídlech',
-        'Na skrzydłach',
-        'Крылья',
-        'ปีกปักษา',
-        '展翅翱翔',
-        '윙스팬',
-      ],
-      thumbnail:
-        'https://cf.geekdo-images.com/itemrep/img/vb971Kg92dzMd1TM3RBJtQm-XCU=/fit-in/246x300/pic4458123.jpg',
-      url: 'https://boardgamegeek.com/boardgame/266192/wingspan',
-      rulebook: null,
-      minPlayers: 1,
-      maxPlayers: 5,
-      resultsSchema: createBoardgameSchema({
-        required: ['score'],
-        properties: {
-          score: {
-            type: 'number' as const,
-          },
-        },
-      }),
+      ...GAMES.gloomhaven.boardgame,
       createdAt: faker.date.between(eras[0], eras[1]),
     }).save(),
     new Boardgame({
-      type: GAME_TYPE.COMPETITIVE,
-      name: 'Gloomhaven (mock)',
-      shortName: 'gloomhaven',
-      aliases: [
-        'Gloomhaven.Мрачная Гавань',
-        'Homályrév',
-        '幽港迷城',
-        '글룸헤이븐',
-      ],
-      thumbnail:
-        'https://cf.geekdo-images.com/itemrep/img/P7MVqNuhAl8Y4fxiM6e74kMX6e0=/fit-in/246x300/pic2437871.jpg',
-      url: 'https://boardgamegeek.com/boardgame/174430/gloomhaven',
-      rulebook: null,
-      minPlayers: 1,
-      maxPlayers: 4,
-      resultsSchema: createBoardgameSchema({}),
+      ...GAMES.wingspan.boardgame,
       createdAt: faker.date.between(eras[0], eras[1]),
     }).save(),
   ])

--- a/packages/server/src/apollo.ts
+++ b/packages/server/src/apollo.ts
@@ -46,7 +46,9 @@ export const connectApolloServer = async (app: IExpress) => {
       }
 
       if (!isNil(error.originalError)) {
-        error.message = `${error.originalError.name}: ${error.originalError.message}`
+        if (error.originalError.name !== 'Error') {
+          error.message = `${error.originalError.name}: ${error.originalError.message}`
+        }
 
         // Better query error message
         if (error.originalError instanceof QueryFailedError) {

--- a/packages/server/src/apollo.ts
+++ b/packages/server/src/apollo.ts
@@ -1,12 +1,15 @@
 import { ApolloServer } from 'apollo-server-express'
+import { UserInputError } from 'apollo-server-errors'
+import CookieParser from 'cookie-parser'
 import Express, { Express as IExpress } from 'express'
 import Helmet from 'helmet'
-import CookieParser from 'cookie-parser'
+import { QueryFailedError } from 'typeorm'
 
 import { config } from '@/config'
 import { contextProvider } from '@/modules/session/session.lib'
 import { createSchema } from '@/graphql'
 import { router } from '@/router'
+import { isNil } from '@/utils'
 
 export const createApp = (): IExpress => {
   const app = Express()
@@ -21,17 +24,42 @@ export const createApp = (): IExpress => {
 
 export const connectApolloServer = async (app: IExpress) => {
   const server = new ApolloServer({
-
     schema: await createSchema(),
     introspection: true,
     context: contextProvider,
-    engine: config.apolloEngine,
+    engine: {
+      rewriteError(err) {
+        if (err instanceof UserInputError) {
+          return null
+        }
+
+        return err
+      },
+      ...config.apolloEngine,
+    },
     formatError(error) {
       // Workaround for apollo adding two UserInputError details for some reason
       if (error.extensions?.code === 'BAD_USER_INPUT') {
         const key = Object.keys(error.extensions.exception)?.[0]
 
         delete error.extensions[key]
+      }
+
+      if (!isNil(error.originalError)) {
+        error.message = `${error.originalError.name}: ${error.originalError.message}`
+
+        // Better query error message
+        if (error.originalError instanceof QueryFailedError) {
+          error.message = `${error.originalError.name}: ${
+            (error.originalError as any)?.detail
+          }`
+        }
+      }
+
+      if (process.env.NODE_ENV === 'production') {
+        if (!isNil(error.extensions)) {
+          delete error.extensions.exception
+        }
       }
 
       return error

--- a/packages/server/src/graphql/snapshot.graphql
+++ b/packages/server/src/graphql/snapshot.graphql
@@ -126,6 +126,7 @@ type Query {
 
     """Maximum 20"""
     limit: Int = 20
+    search: String
   ): BoardgamesPage!
   club(uuid: ID!): Club
   match(uuid: ID!): Match

--- a/packages/server/src/modules/boardgame/boardgame.model.ts
+++ b/packages/server/src/modules/boardgame/boardgame.model.ts
@@ -198,10 +198,15 @@ export class Boardgame extends ExtendedEntity {
     }
 
     const games = await this.find({ select: ['uuid', 'name', 'shortName'] })
+
+    const aliases = games
+      .map<CachedNames>(game => game.aliases.map(alias => [alias, game.uuid]))
+      .flat()
     const names = games
       .map<CachedNames>(game => [
         [game.name, game.uuid],
         [game.shortName, game.uuid],
+        ...aliases,
       ])
       .flat()
 

--- a/packages/server/src/modules/boardgame/boardgame.model.ts
+++ b/packages/server/src/modules/boardgame/boardgame.model.ts
@@ -4,6 +4,7 @@ import { Field, Int, ObjectType, registerEnumType } from 'type-graphql'
 import { Column, Entity, Index } from 'typeorm'
 import { IsLowercase, IsUrl, MaxLength, Min } from 'class-validator'
 import AJV from 'ajv'
+import Cache from 'node-cache'
 
 import { ExtendedEntity } from '@/modules/exented-entity'
 import { JsonSchemaArray, JsonSchemaObject } from '@/types/json-schema'
@@ -48,6 +49,15 @@ const ajv = new AJV({
   allErrors: true,
 })
 const validateMinimumSchema = ajv.compile(minimumResultsSchema)
+
+const isDev = process.env.NODE_ENV === 'development'
+const cache = new Cache({
+  checkperiod: 500,
+  stdTTL: isDev ? 1 : 60 * 1000,
+  useClones: false,
+})
+
+type CachedNames = Array<[string, string]>
 
 @Entity()
 @ObjectType()
@@ -139,7 +149,7 @@ export class Boardgame extends ExtendedEntity {
 
   public static validateMinimumResultsSchema(
     schema: object,
-    path?: string
+    path?: string,
   ): schema is MinimumResultsSchema {
     const result = validateMinimumSchema(schema, path)
 
@@ -179,5 +189,24 @@ export class Boardgame extends ExtendedEntity {
 
   public static async shortNameExists(shortName: string) {
     return (await Boardgame.count({ shortName })) > 0
+  }
+
+  private static cacheKey = 'names'
+  public static async getBoardgameNames(): Promise<CachedNames> {
+    if (cache.has(this.cacheKey)) {
+      return cache.get<CachedNames>(this.cacheKey)!
+    }
+
+    const games = await this.find({ select: ['uuid', 'name', 'shortName'] })
+    const names = games
+      .map<CachedNames>(game => [
+        [game.name, game.uuid],
+        [game.shortName, game.uuid],
+      ])
+      .flat()
+
+    cache.set<CachedNames>(this.cacheKey, names)
+
+    return names
   }
 }

--- a/packages/server/src/modules/boardgame/boardgame.model.ts
+++ b/packages/server/src/modules/boardgame/boardgame.model.ts
@@ -176,4 +176,8 @@ export class Boardgame extends ExtendedEntity {
       throw createValidationError(validate.errors!, 'Invalid metadata!')
     }
   }
+
+  public static async shortNameExists(shortName: string) {
+    return (await Boardgame.count({ shortName })) > 0
+  }
 }

--- a/packages/server/src/modules/boardgame/boardgame.model.ts
+++ b/packages/server/src/modules/boardgame/boardgame.model.ts
@@ -197,7 +197,7 @@ export class Boardgame extends ExtendedEntity {
       return cache.get<CachedNames>(this.cacheKey)!
     }
 
-    const games = await this.find({ select: ['uuid', 'name', 'shortName'] })
+    const games = await this.find({ select: ['uuid', 'name', 'shortName', 'aliases'] })
 
     const aliases = games
       .map<CachedNames>(game => game.aliases.map(alias => [alias, game.uuid]))

--- a/packages/server/src/modules/boardgame/boardgame.resolvers.ts
+++ b/packages/server/src/modules/boardgame/boardgame.resolvers.ts
@@ -46,6 +46,8 @@ export class BoardgameResolver {
   ): Promise<BoardgamesPage> {
     const boardgames = await Boardgame.find({ ...args.getFilters() })
     const count = await Boardgame.count({ ...args.getFilters() })
+    const boardgames = await Boardgame.find({ ...args.getPageFilters() })
+    const count = await Boardgame.count({ ...args.getPageFilters() })
 
     const nextOffset = args.offset + args.limit
     return {

--- a/packages/server/src/modules/boardgame/boardgame.resolvers.ts
+++ b/packages/server/src/modules/boardgame/boardgame.resolvers.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
+import { UserInputError } from 'apollo-server-errors'
 import Ajv from 'ajv'
 import { GraphQLJSONObject } from 'graphql-type-json'
 import {
@@ -76,9 +77,15 @@ export class BoardgameResolver {
     @Arg('metadataSchema', () => GraphQLJSONObject, { nullable: true })
     metadataSchema: object | null,
   ) {
+    if (await Boardgame.shortNameExists(shortName)) {
+      throw new UserInputError(`Short name "${shortName}" already exists!`)
+    }
+
     // TODO: Move schema validation to a custom GQL type
     // TODO: actually validate against the minimum result schema
-    if (!Boardgame.validateMinimumResultsSchema(resultsSchema, 'resultsSchema')) {
+    if (
+      !Boardgame.validateMinimumResultsSchema(resultsSchema, 'resultsSchema')
+    ) {
       throw createValidationError(validate.errors!, 'Invalid resultSchema!')
     }
     if (!isNil(metadataSchema) && !validate(metadataSchema)) {

--- a/packages/server/src/modules/boardgame/boardgame.test.ts
+++ b/packages/server/src/modules/boardgame/boardgame.test.ts
@@ -4,6 +4,7 @@ import gql from 'graphql-tag'
 import { connectToDatabase } from '@/db'
 import { createApolloClient, generateUser, TestClient } from '@/utils/tests'
 import { GAMES } from '@/utils/test-data'
+import { Boardgame } from '@/modules/boardgame/boardgame.model'
 
 let client: TestClient
 let dbConnection: DBConnection
@@ -37,7 +38,7 @@ describe('resolvers', () => {
           name: $name
           shortName: $shortName
           aliases: $aliases
-          thumbnail: $thumbnail,
+          thumbnail: $thumbnail
           url: $url
           maxPlayers: $maxPlayers
           resultsSchema: $resultsSchema
@@ -225,6 +226,32 @@ describe('resolvers', () => {
           },
         },
       ])
+    })
+  })
+})
+
+describe('statics', () => {
+  describe('getBoardgameNames', () => {
+    const testData = [GAMES.azul, GAMES.scythe] as const
+    let games: Boardgame[] = []
+
+    beforeEach(async () => {
+      games = await Promise.all(testData.map(data => data.boardgame.save()))
+    })
+
+    test('returns name:uuid map', async () => {
+      const result = await Boardgame.getBoardgameNames()
+
+      const expectedResult = Object.fromEntries(
+        games
+          .map(boardgame => [
+            [boardgame.name, boardgame.uuid],
+            [boardgame.shortName, boardgame.uuid],
+          ])
+          .flat(),
+      )
+
+      expect(result).toMatchObject(expectedResult)
     })
   })
 })

--- a/packages/server/src/modules/boardgame/boardgame.test.ts
+++ b/packages/server/src/modules/boardgame/boardgame.test.ts
@@ -242,10 +242,8 @@ describe('resolvers', () => {
         }
       }
     `
-    let boardgames: Boardgame[] = []
-
     beforeEach(async () => {
-      boardgames = await mapAsync(getTestBoardgames(), game => game.save())
+      await mapAsync(getTestBoardgames(), game => game.save())
     })
 
     test('search works as intended', async () => {

--- a/packages/server/src/modules/boardgame/boardgame.test.ts
+++ b/packages/server/src/modules/boardgame/boardgame.test.ts
@@ -282,26 +282,34 @@ describe('resolvers', () => {
 
 describe('statics', () => {
   describe('getBoardgameNames', () => {
-    const testData = [GAMES.azul, GAMES.scythe] as const
     let games: Boardgame[] = []
 
     beforeEach(async () => {
-      games = await Promise.all(testData.map(data => data.boardgame.save()))
+      games = await Promise.all(
+        getTestBoardgames().map(boardgame => boardgame.save()),
+      )
     })
 
     test('returns name:uuid map', async () => {
       const result = await Boardgame.getBoardgameNames()
 
-      const expectedResult = Object.fromEntries(
-        games
-          .map(boardgame => [
-            [boardgame.name, boardgame.uuid],
-            [boardgame.shortName, boardgame.uuid],
-          ])
-          .flat(),
-      )
+      const aliases = games
+        .map(game => game.aliases.map(alias => [alias, game.uuid]))
+        .flat()
+      const expectedResult = games
+        .map(game => {
+          return [
+            [game.name, game.uuid],
+            [game.shortName, game.uuid],
+            ...aliases,
+          ]
+        })
+        .flat()
 
-      expect(result).toMatchObject(expectedResult)
+      const sortedResult = result.sort((a, b) => a[0].localeCompare(b[0]))
+      const sortedExpectedResult = expectedResult.sort((a, b) => a[0].localeCompare(b[0]))
+
+      expect(sortedResult).toMatchObject(sortedExpectedResult)
     })
   })
 })

--- a/packages/server/src/modules/pagination.ts
+++ b/packages/server/src/modules/pagination.ts
@@ -28,7 +28,7 @@ export class PaginationArgs {
   @Max(20)
   public limit: number = 20
 
-  public getFilters = (): FindManyOptions => ({
+  public getPageFilters = (): FindManyOptions => ({
     take: this.limit,
     skip: this.offset,
   })

--- a/packages/server/src/modules/pagination.ts
+++ b/packages/server/src/modules/pagination.ts
@@ -18,6 +18,12 @@ export const PaginatedResponse = <TItem>(TItemClass: ClassType<TItem>) => {
   return PaginatedResponseClass
 }
 
+PaginatedResponse.EMPTY_PAGE = {
+  items: [],
+  nextOffset: null,
+  total: 0,
+}
+
 @ArgsType()
 export class PaginationArgs {
   @Field(() => Int, { nullable: true })

--- a/packages/server/src/utils/index.ts
+++ b/packages/server/src/utils/index.ts
@@ -66,3 +66,5 @@ export const createDescription = (
 
   return `${desc}${loginStr}${ownerStr}${devStr}`
 }
+
+export const removeDuplicates = <T>(arr: T[]): T[] => Array.from(new Set(arr))

--- a/packages/server/src/utils/test-data.ts
+++ b/packages/server/src/utils/test-data.ts
@@ -215,6 +215,22 @@ export const GAMES = {
     }),
     generateResult: defaultResultGenerator,
   },
+  wonders: {
+    boardgame: new Boardgame({
+      type: GAME_TYPE.COMPETITIVE,
+      name: '7 Wonders (mock)',
+      shortName: '7-wonders',
+      aliases: [],
+      thumbnail:
+        'https://cf.geekdo-images.com/itemrep/img/fR5_q-7pMDmhLP8SPLOwPcUeLVo=/fit-in/246x300/pic860217.jpg',
+      url: 'https://boardgamegeek.com/boardgame/68448/7-wonders',
+      rulebook: null,
+      minPlayers: 2,
+      maxPlayers: 7,
+      resultsSchema: defaultSchema,
+    }),
+    generateResult: defaultResultGenerator,
+  },
 } as const
 
 export const getTestBoardgames = () =>

--- a/packages/server/src/utils/test-data.ts
+++ b/packages/server/src/utils/test-data.ts
@@ -3,6 +3,39 @@ import faker from 'faker'
 
 faker.seed(12)
 
+const defaultSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#' as const,
+  type: 'object' as const,
+  required: ['player', 'winner', 'final'],
+  properties: {
+    player: {
+      type: 'string' as const,
+    },
+    winner: {
+      type: 'boolean' as const,
+    },
+    final: {
+      type: 'number' as const,
+    },
+  },
+}
+
+const defaultResultGenerator = (users: Array<{ uuid: string }>) => {
+  const winner = faker.random.arrayElement(users)
+
+  return users.map(user => {
+    const isWinner = winner.uuid === user.uuid
+
+    return {
+      player: user.uuid,
+      winner: isWinner,
+      final: isWinner
+        ? faker.random.number({ min: 50, max: 80 })
+        : faker.random.number(50),
+    }
+  })
+}
+
 export const GAMES = {
   azul: {
     boardgame: new Boardgame({
@@ -16,38 +49,9 @@ export const GAMES = {
       rulebook: null,
       minPlayers: 2,
       maxPlayers: 4,
-      resultsSchema: {
-        $schema: 'http://json-schema.org/draft-07/schema#',
-        type: 'object',
-        required: ['player', 'winner', 'final'],
-        properties: {
-          player: {
-            type: 'string' as const,
-          },
-          winner: {
-            type: 'boolean' as const,
-          },
-          final: {
-            type: 'number' as const,
-          },
-        },
-      },
+      resultsSchema: defaultSchema,
     }),
-    generateResult: (users: Array<{ uuid: string }>) => {
-      const winner = faker.random.arrayElement(users)
-
-      return users.map(user => {
-        const isWinner = winner.uuid === user.uuid
-
-        return {
-          player: user.uuid,
-          winner: isWinner,
-          final: isWinner
-            ? faker.random.number({ min: 50, max: 80 })
-            : faker.random.number(50),
-        }
-      })
-    },
+    generateResult: defaultResultGenerator,
   },
   scythe: {
     boardgame: new Boardgame({
@@ -137,4 +141,81 @@ export const GAMES = {
       })
     },
   },
+  mars: {
+    boardgame: new Boardgame({
+      type: GAME_TYPE.COMPETITIVE,
+      name: 'Terraforming Mars (mock)',
+      shortName: 'terraforming-mars',
+      aliases: [
+        'A Mars terraformálása',
+        'Mars: Teraformace',
+        'Teraformarea Planetei Marte',
+        'Terraformacja Marsa',
+        'Покорение Марса',
+        'Тераформирай Марс',
+        'Тераформування Марса',
+        'พลิกพิภพดาวอังคาร',
+        'テラフォーミング・マーズ',
+        '殖民火星',
+        '테라포밍 마스',
+      ],
+      thumbnail:
+        'https://cf.geekdo-images.com/itemrep/img/bhemoxL7PG1a_79L0D9syPTADSY=/fit-in/246x300/pic3536616.jpg',
+      url: 'https://boardgamegeek.com/boardgame/167791/terraforming-mars',
+      rulebook: null,
+      minPlayers: 1,
+      maxPlayers: 5,
+      resultsSchema: defaultSchema,
+    }),
+    generateResult: defaultResultGenerator,
+  },
+  gloomhaven: {
+    boardgame: new Boardgame({
+      type: GAME_TYPE.COMPETITIVE,
+      name: 'Gloomhaven (mock)',
+      shortName: 'gloomhaven',
+      aliases: [
+        'Gloomhaven.Мрачная Гавань',
+        'Homályrév',
+        '幽港迷城',
+        '글룸헤이븐',
+      ],
+      thumbnail:
+        'https://cf.geekdo-images.com/itemrep/img/P7MVqNuhAl8Y4fxiM6e74kMX6e0=/fit-in/246x300/pic2437871.jpg',
+      url: 'https://boardgamegeek.com/boardgame/174430/gloomhaven',
+      rulebook: null,
+      minPlayers: 1,
+      maxPlayers: 4,
+      resultsSchema: defaultSchema,
+    }),
+    generateResult: defaultResultGenerator,
+  },
+  wingspan: {
+    boardgame: new Boardgame({
+      type: GAME_TYPE.COMPETITIVE,
+      name: 'Wingspan (mock)',
+      shortName: 'wingspan',
+      aliases: [
+        'Fesztáv',
+        'Flügelschlag',
+        'Na křídlech',
+        'Na skrzydłach',
+        'Крылья',
+        'ปีกปักษา',
+        '展翅翱翔',
+        '윙스팬',
+      ],
+      thumbnail:
+        'https://cf.geekdo-images.com/itemrep/img/vb971Kg92dzMd1TM3RBJtQm-XCU=/fit-in/246x300/pic4458123.jpg',
+      url: 'https://boardgamegeek.com/boardgame/266192/wingspan',
+      rulebook: null,
+      minPlayers: 1,
+      maxPlayers: 5,
+      resultsSchema: defaultSchema,
+    }),
+    generateResult: defaultResultGenerator,
+  },
 } as const
+
+export const getTestBoardgames = () =>
+  Object.keys(GAMES).map(key => GAMES[key as keyof typeof GAMES].boardgame)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8479,6 +8479,11 @@ functions-have-names@^1.1.1:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.0.tgz#83da7583e4ea0c9ac5ff530f73394b033e0bf77d"
   integrity sha512-zKXyzksTeaCSw5wIX79iCA40YAa6CJMJgNg9wdkU/ERBrIdPSimPICYiLp65lRbSBqtiHql/HZfS2DyI/AH6tQ==
 
+fuse.js@3.4.6:
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.4.6.tgz#545c3411fed88bf2e27c457cab6e73e7af697a45"
+  integrity sha512-H6aJY4UpLFwxj1+5nAvufom5b2BT2v45P1MkPvdGIK8fWjQx/7o6tTT1+ALV0yawQvbmvCF0ufl2et8eJ7v7Cg==
+
 fuse.js@^3.4.4:
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.4.5.tgz#8954fb43f9729bd5dbcb8c08f251db552595a7a6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5841,6 +5841,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
@@ -11938,6 +11943,13 @@ nocache@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.1.0.tgz#120c9ffec43b5729b1d5de88cd71aa75a0ba491f"
   integrity sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==
+
+node-cache@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.0.tgz#266786c28dcec0fd34385ee29c383e6d6f1aa5de"
+  integrity sha512-gFQwYdoOztBuPlwg6DKQEf50G+gkK69aqLnw4djkmlHCzeVrLJfwvg9xl4RCAGviTIMUVoqcyoZ/V/wPEu/VVg==
+  dependencies:
+    clone "2.x"
 
 node-dir@^0.1.10:
   version "0.1.17"


### PR DESCRIPTION
- Adds `search` argument to `boardgames`.
- Removes stack traces from production errors.
- Logs usable messages from query errors.

Story details: https://app.clubhouse.io/scorekeep/story/13